### PR TITLE
Add REST APIs to the application

### DIFF
--- a/src/main/java/org/codewithmagret/rest/member/Member.java
+++ b/src/main/java/org/codewithmagret/rest/member/Member.java
@@ -1,5 +1,6 @@
 package org.codewithmagret.rest.member;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.persistence.*;
 import org.codewithmagret.rest.tournament.Tournament;
 
@@ -17,6 +18,9 @@ import java.util.Set;
  * and duration of membership are all required fields that provide essential
  */
 @Entity
+@Table(name = "member", uniqueConstraints = {
+        @UniqueConstraint(columnNames = {"email"})
+})
 public class Member {
     /**
      * The unique identifier for the member.
@@ -70,6 +74,7 @@ public class Member {
      * Tournaments the member is participating in.
      * This is the inverse side of the many-to-many relationship.
      */
+    @JsonIgnore
     @ManyToMany(mappedBy = "members")
     private Set<Tournament> tournaments =  new HashSet<>();
 

--- a/src/main/java/org/codewithmagret/rest/member/MemberController.java
+++ b/src/main/java/org/codewithmagret/rest/member/MemberController.java
@@ -1,0 +1,127 @@
+package org.codewithmagret.rest.member;
+
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDate;
+import java.util.List;
+
+/**
+ * REST controller for Member endpoints.
+ */
+@RestController
+@RequestMapping("/members")
+public class MemberController {
+
+    private final MemberService memberService;
+
+    /**
+     * Constructs a MemberController.
+     *
+     * @param memberService member service
+     */
+    public MemberController(MemberService memberService) {
+        this.memberService = memberService;
+    }
+
+    /**
+     * Creates a new member.
+     *
+     * @param member member request body
+     * @return saved member
+     */
+    @PostMapping
+    public Member createMember(@RequestBody Member member) {
+        return memberService.createMember(member);
+    }
+
+    /**
+     * Returns all members.
+     *
+     * @return list of members
+     */
+    @GetMapping
+    public List<Member> getAllMembers() {
+        return memberService.getAllMembers();
+    }
+
+    /**
+     * Returns a member by ID.
+     *
+     * @param id member ID
+     * @return matching member
+     */
+    @GetMapping("/{id}")
+    public Member getMemberById(@PathVariable Long id) {
+        return memberService.getMemberById(id);
+    }
+
+    /**
+     * Searches members by name.
+     *
+     * @param name member name
+     * @return list of matching members
+     */
+    @GetMapping("/search/name")
+    public List<Member> searchByName(@RequestParam String name) {
+        return memberService.searchByName(name);
+    }
+
+    /**
+     * Searches members by membership type.
+     *
+     * @param type membership type
+     * @return list of matching members
+     */
+    @GetMapping("/search/type")
+    public List<Member> searchByMembershipType(@RequestParam String type) {
+        return memberService.searchByMembershipType(type);
+    }
+
+    /**
+     * Searches members by phone number.
+     *
+     * @param phone phone number
+     * @return list of matching members
+     */
+    @GetMapping("/search/phone")
+    public List<Member> searchByPhoneNumber(@RequestParam String phone) {
+        return memberService.searchByPhoneNumber(phone);
+    }
+
+    /**
+     * Searches members by tournament start date.
+     *
+     * @param startDate tournament start date
+     * @return list of matching members
+     */
+    @GetMapping("/search/tournament-date")
+    public List<Member> searchByTournamentStartDate(
+            @RequestParam
+            @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate startDate
+    ) {
+        return memberService.searchByTournamentStartDate(startDate);
+    }
+
+    /**
+     * Updates an existing member.
+     *
+     * @param id member ID
+     * @param member updated member data
+     * @return updated member
+     */
+    @PutMapping("/{id}")
+    public Member updateMember(@PathVariable Long id, @RequestBody Member member) {
+        return memberService.updateMember(id, member);
+    }
+
+    /**
+     * Deletes a member by ID.
+     *
+     * @param id member ID
+     */
+    @DeleteMapping("/{id}")
+    public void deleteMember(@PathVariable Long id) {
+        memberService.deleteMember(id);
+    }
+}

--- a/src/main/java/org/codewithmagret/rest/member/MemberRepository.java
+++ b/src/main/java/org/codewithmagret/rest/member/MemberRepository.java
@@ -1,0 +1,55 @@
+package org.codewithmagret.rest.member;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Repository for Member entity operations.
+ */
+public interface MemberRepository extends JpaRepository<Member, Long> {
+
+    /**
+     * Finds members whose names contain the given value, ignoring case.
+     *
+     * @param name member name
+     * @return list of matching members
+     */
+    List<Member> findByNameContainingIgnoreCase(String name);
+
+    /**
+     * Finds members by membership type, ignoring case.
+     *
+     * @param membershipType membership type
+     * @return list of matching members
+     */
+    List<Member> findByMembershipTypeIgnoreCase(String membershipType);
+
+    /**
+     * Finds members by phone number.
+     *
+     * @param phoneNumber phone number
+     * @return list of matching members
+     */
+    List<Member> findByPhoneNumber(String phoneNumber);
+
+    /**
+     * Finds members participating in tournaments with the given start date.
+     *
+     * @param startDate tournament start date
+     * @return list of matching members
+     */
+    @Query("SELECT DISTINCT m FROM Member m JOIN m.tournaments t WHERE t.startDate = :startDate")
+    List<Member> findMembersByTournamentStartDate(@Param("startDate") LocalDate startDate);
+
+    /**
+     * Finds members by email
+     * @param email email of member
+     * @return true or false
+     */
+    boolean existsByEmail(String email);
+}

--- a/src/main/java/org/codewithmagret/rest/member/MemberService.java
+++ b/src/main/java/org/codewithmagret/rest/member/MemberService.java
@@ -1,0 +1,161 @@
+package org.codewithmagret.rest.member;
+
+import org.codewithmagret.rest.tournament.Tournament;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Service class for Member business logic.
+ */
+@Service
+public class MemberService {
+
+    private final MemberRepository memberRepository;
+
+    /**
+     * Constructs a MemberService.
+     *
+     * @param memberRepository member repository
+     */
+    public MemberService(MemberRepository memberRepository) {
+        this.memberRepository = memberRepository;
+    }
+
+    /**
+     * Creates and saves a new member.
+     *
+     * @param member member to save
+     * @return saved member
+     */
+    public Member createMember(Member member) {
+        if (member == null) {
+            throw new IllegalArgumentException("member is empty");
+        }
+
+        if (member.getEmail() == null || member.getEmail().trim().isEmpty()) {
+            throw new IllegalArgumentException("Email is required");
+        }
+
+        Member existing = memberRepository.existsByEmail(member.getEmail()) ? member : null;
+        if (existing != null) {
+            throw new IllegalArgumentException("member email already exists");
+        }
+
+        return memberRepository.save(member);
+    }
+
+    /**
+     * Returns all members.
+     *
+     * @return list of members
+     */
+    public List<Member> getAllMembers() {
+        if (memberRepository.findAll().isEmpty()) {
+            throw new IllegalArgumentException("Member list is empty");
+        }
+        return memberRepository.findAll();
+    }
+
+    /**
+     * Returns a member by ID.
+     *
+     * @param id member ID
+     * @return matching member
+     */
+    public Member getMemberById(Long id) {
+        return memberRepository.findById(id)
+                .orElseThrow(() -> new RuntimeException("Member not found with id: " + id));
+    }
+
+    /**
+     * Searches members by name.
+     *
+     * @param name member name
+     * @return list of matching members
+     */
+    public List<Member> searchByName(String name) {
+        if (name == null || name.isEmpty()) {
+            throw new IllegalArgumentException("name is empty");
+        }
+        return memberRepository.findByNameContainingIgnoreCase(name);
+    }
+
+    /**
+     * Searches members by membership type.
+     *
+     * @param membershipType membership type
+     * @return list of matching members
+     */
+    public List<Member> searchByMembershipType(String membershipType) {
+        if (membershipType == null || membershipType.isEmpty()) {
+            throw new IllegalArgumentException("membershipType is empty");
+        }
+        return memberRepository.findByMembershipTypeIgnoreCase(membershipType);
+    }
+
+    /**
+     * Searches members by phone number.
+     *
+     * @param phoneNumber phone number
+     * @return list of matching members
+     */
+    public List<Member> searchByPhoneNumber(String phoneNumber) {
+        if (phoneNumber == null || phoneNumber.isEmpty()) {
+            throw new IllegalArgumentException("phoneNumber is empty");
+        }
+        return memberRepository.findByPhoneNumber(phoneNumber);
+    }
+
+    /**
+     * Searches members by tournament start date.
+     *
+     * @param startDate tournament start date
+     * @return list of matching members
+     */
+    public List<Member> searchByTournamentStartDate(LocalDate startDate) {
+        if (startDate == null || startDate.isBefore(LocalDate.now())) {
+            throw new IllegalArgumentException("startDate is empty");
+        }
+        return memberRepository.findMembersByTournamentStartDate(startDate);
+    }
+
+    /**
+     * Updates an existing member.
+     *
+     * @param id member ID
+     * @param updatedMember updated member data
+     * @return updated member
+     */
+    public Member updateMember(Long id, Member updatedMember) {
+        Member existingMember = memberRepository.findById(id)
+                .orElseThrow(() -> new RuntimeException("Member not found with id: " + id));
+
+        existingMember.setName(updatedMember.getName());
+        existingMember.setAddress(updatedMember.getAddress());
+        existingMember.setEmail(updatedMember.getEmail());
+        existingMember.setMembershipType(updatedMember.getMembershipType());
+        existingMember.setPhoneNumber(updatedMember.getPhoneNumber());
+        existingMember.setMembershipStartDate(updatedMember.getMembershipStartDate());
+        existingMember.setMembershipDuration(updatedMember.getMembershipDuration());
+
+        return memberRepository.save(existingMember);
+    }
+
+    /**
+     * Deletes a member by ID.
+     *
+     * @param id member ID
+     */
+    public void deleteMember(Long id) {
+        Member member = memberRepository.findById(id)
+                .orElseThrow(() -> new RuntimeException("Member not found with id: " + id));
+
+        for (Tournament tournament : Set.copyOf(member.getTournaments())) {
+            tournament.removeMember(member);
+        }
+        memberRepository.delete(member);
+    }
+}

--- a/src/main/java/org/codewithmagret/rest/tournament/Tournament.java
+++ b/src/main/java/org/codewithmagret/rest/tournament/Tournament.java
@@ -3,11 +3,15 @@ package org.codewithmagret.rest.tournament;
 import jakarta.persistence.*;
 import org.codewithmagret.rest.member.Member;
 
+import java.time.LocalDate;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
 @Entity
+@Table(
+        uniqueConstraints = @UniqueConstraint(columnNames = {"startDate", "location"})
+)
 public class Tournament {
     /**
      * ID of each tournament
@@ -19,12 +23,12 @@ public class Tournament {
     /**
      * Start date of tournament
      */
-    private String startDate;
+    private LocalDate startDate;
 
     /**
      * End date of tournament
      */
-    private String endDate;
+    private LocalDate endDate;
 
     /**
      * Location of tournament
@@ -74,7 +78,7 @@ public class Tournament {
      * Gets the start date of tournament
      * @return startDate of the tournament
      */
-    public String getStartDate() {
+    public LocalDate getStartDate() {
         return startDate;
     }
 
@@ -82,7 +86,7 @@ public class Tournament {
      * Sets the startdate of the tournament
      * @param startDate of the tournament
      */
-    public void setStartDate(String startDate) {
+    public void setStartDate(LocalDate startDate) {
         this.startDate = startDate;
     }
 
@@ -106,7 +110,7 @@ public class Tournament {
      * Gets end date of the tournament
      * @return endDate of the tournament
      */
-    public String getEndDate() {
+    public LocalDate getEndDate() {
         return endDate;
     }
 
@@ -114,7 +118,7 @@ public class Tournament {
      * Sets end date of the tournament
      * @param endDate of the tournament
      */
-    public void setEndDate(String endDate) {
+    public void setEndDate(LocalDate endDate) {
         this.endDate = endDate;
     }
 

--- a/src/main/java/org/codewithmagret/rest/tournament/TournamentController.java
+++ b/src/main/java/org/codewithmagret/rest/tournament/TournamentController.java
@@ -1,0 +1,140 @@
+package org.codewithmagret.rest.tournament;
+
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDate;
+import java.util.List;
+
+/**
+ * REST controller for Tournament endpoints.
+ */
+@RestController
+@RequestMapping("/tournaments")
+public class TournamentController {
+
+    private final TournamentService tournamentService;
+
+    /**
+     * Constructs a TournamentController.
+     *
+     * @param tournamentService tournament service
+     */
+    public TournamentController(TournamentService tournamentService) {
+        this.tournamentService = tournamentService;
+    }
+
+    /**
+     * Creates a new tournament.
+     *
+     * @param tournament tournament request body
+     * @return saved tournament
+     */
+    @PostMapping
+    public Tournament createTournament(@RequestBody Tournament tournament) {
+        return tournamentService.createTournament(tournament);
+    }
+
+    /**
+     * Returns all tournaments.
+     *
+     * @return list of tournaments
+     */
+    @GetMapping
+    public List<Tournament> getAllTournaments() {
+        return tournamentService.getAllTournaments();
+    }
+
+    /**
+     * Returns a tournament by ID.
+     *
+     * @param id tournament ID
+     * @return matching tournament
+     */
+    @GetMapping("/{id}")
+    public Tournament getTournamentById(@PathVariable Long id) {
+        return tournamentService.getTournamentById(id);
+    }
+
+    /**
+     * Adds a member to a tournament.
+     *
+     * @param tournamentId tournament ID
+     * @param memberId member ID
+     * @return updated tournament
+     */
+    @PostMapping("/{tournamentId}/members/{memberId}")
+    public Tournament addMemberToTournament(@PathVariable Long tournamentId, @PathVariable Long memberId) {
+        return tournamentService.addMemberToTournament(tournamentId, memberId);
+    }
+
+    /**
+     * Removes a member from a tournament.
+     *
+     * @param tournamentId tournament ID
+     * @param memberId member ID
+     * @return updated tournament
+     */
+    @DeleteMapping("/{tournamentId}/members/{memberId}")
+    public Tournament removeMemberFromTournament(@PathVariable Long tournamentId, @PathVariable Long memberId) {
+        return tournamentService.removeMemberFromTournament(tournamentId, memberId);
+    }
+
+    /**
+     * Searches tournaments by start date.
+     *
+     * @param startDate tournament start date
+     * @return list of matching tournaments
+     */
+    @GetMapping("/search/date")
+    public List<Tournament> searchByStartDate(
+            @RequestParam
+            @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate startDate
+    ) {
+        return tournamentService.searchByStartDate(startDate);
+    }
+
+    /**
+     * Searches tournaments by location.
+     *
+     * @param location tournament location
+     * @return list of matching tournaments
+     */
+    @GetMapping("/search/location")
+    public List<Tournament> searchByLocation(@RequestParam String location) {
+        return tournamentService.searchByLocation(location);
+    }
+
+    /**
+     * Searches tournaments by member ID.
+     *
+     * @param memberId member ID
+     * @return list of matching tournaments
+     */
+    @GetMapping("/search/member/{memberId}")
+    public List<Tournament> searchByMember(@PathVariable Long memberId) {
+        return tournamentService.searchByMember(memberId);
+    }
+
+    /**
+     * Updates an existing tournament.
+     *
+     * @param id tournament ID
+     * @param tournament updated tournament data
+     * @return updated tournament
+     */
+    @PutMapping("/{id}")
+    public Tournament updateTournament(@PathVariable Long id, @RequestBody Tournament tournament) {
+        return tournamentService.updateTournament(id, tournament);
+    }
+
+    /**
+     * Deletes a tournament by ID.
+     *
+     * @param id tournament ID
+     */
+    @DeleteMapping("/{id}")
+    public void deleteTournament(@PathVariable Long id) {
+        tournamentService.deleteTournament(id);
+    }
+}

--- a/src/main/java/org/codewithmagret/rest/tournament/TournamentRepository.java
+++ b/src/main/java/org/codewithmagret/rest/tournament/TournamentRepository.java
@@ -1,0 +1,46 @@
+package org.codewithmagret.rest.tournament;
+
+import org.codewithmagret.rest.member.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.LocalDate;
+import java.util.List;
+
+/**
+ * Repository for Tournament entity operations.
+ */
+public interface TournamentRepository extends JpaRepository<Tournament, Long> {
+
+    /**
+     * Finds tournaments by start date.
+     *
+     * @param startDate tournament start date
+     * @return list of matching tournaments
+     */
+    List<Tournament> findByStartDate(LocalDate startDate);
+
+    /**
+     * Finds tournaments whose location contains the given value, ignoring case.
+     *
+     * @param location location
+     * @return list of matching tournaments
+     */
+    List<Tournament> findByLocationContainingIgnoreCase(String location);
+
+    /**
+     * Finds tournaments containing the given member.
+     *
+     * @param member member
+     * @return list of matching tournaments
+     */
+    List<Tournament> findByMembersContaining(Member member);
+
+    /**
+     * Checks if a tournament exists with the given start date and location.
+     *
+     * @param startDate tournament start date
+     * @param location tournament location
+     * @return true if exists, false otherwise
+     */
+    boolean existsByStartDateAndLocationIgnoreCase(LocalDate startDate, String location);
+}

--- a/src/main/java/org/codewithmagret/rest/tournament/TournamentService.java
+++ b/src/main/java/org/codewithmagret/rest/tournament/TournamentService.java
@@ -1,0 +1,187 @@
+package org.codewithmagret.rest.tournament;
+
+import org.codewithmagret.rest.member.Member;
+import org.codewithmagret.rest.member.MemberRepository;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Service class for Tournament business logic.
+ */
+@Service
+public class TournamentService {
+
+    private final TournamentRepository tournamentRepository;
+    private final MemberRepository memberRepository;
+
+    /**
+     * Constructs a TournamentService.
+     *
+     * @param tournamentRepository tournament repository
+     * @param memberRepository member repository
+     */
+    public TournamentService(TournamentRepository tournamentRepository, MemberRepository memberRepository) {
+        this.tournamentRepository = tournamentRepository;
+        this.memberRepository = memberRepository;
+    }
+
+    /**
+     * Creates and saves a new tournament.
+     *
+     * @param tournament tournament to save
+     * @return saved tournament
+     */
+    public Tournament createTournament(Tournament tournament) {
+        if (tournament == null) {
+            throw new IllegalArgumentException("tournament is null");
+        }
+
+        if (tournament.getStartDate() == null || tournament.getLocation() == null) {
+            throw new IllegalArgumentException("Start date and location are required");
+        }
+
+        boolean exists = tournamentRepository.existsByStartDateAndLocationIgnoreCase(
+                tournament.getStartDate(),
+                tournament.getLocation()
+        );
+
+        if (exists) {
+            throw new IllegalArgumentException("Tournament already exists with same start date and location");
+        }
+
+        return tournamentRepository.save(tournament);
+    }
+
+    /**
+     * Returns all tournaments.
+     *
+     * @return list of tournaments
+     */
+    public List<Tournament> getAllTournaments() {
+        if (tournamentRepository.findAll().isEmpty()) {
+            throw new IllegalArgumentException("tournament is empty");
+        }
+        return tournamentRepository.findAll();
+    }
+
+    /**
+     * Returns a tournament by ID.
+     *
+     * @param id tournament ID
+     * @return matching tournament
+     */
+    public Tournament getTournamentById(Long id) {
+        return tournamentRepository.findById(id)
+                .orElseThrow(() -> new RuntimeException("Tournament not found with id: " + id));
+    }
+
+    /**
+     * Adds a member to a tournament.
+     *
+     * @param tournamentId tournament ID
+     * @param memberId member ID
+     * @return updated tournament
+     */
+    public Tournament addMemberToTournament(Long tournamentId, Long memberId) {
+        Tournament tournament = tournamentRepository.findById(tournamentId)
+                .orElseThrow(() -> new RuntimeException("Tournament not found with id: " + tournamentId));
+
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new RuntimeException("Member not found with id: " + memberId));
+
+        tournament.addMember(member);
+
+        return tournamentRepository.save(tournament);
+    }
+
+    /**
+     * Removes a member from a tournament.
+     *
+     * @param tournamentId tournament ID
+     * @param memberId member ID
+     * @return updated tournament
+     */
+    public Tournament removeMemberFromTournament(Long tournamentId, Long memberId) {
+        Tournament tournament = tournamentRepository.findById(tournamentId)
+                .orElseThrow(() -> new RuntimeException("Tournament not found with id: " + tournamentId));
+
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new RuntimeException("Member not found with id: " + memberId));
+
+        tournament.removeMember(member);
+
+        return tournamentRepository.save(tournament);
+    }
+
+    /**
+     * Searches tournaments by start date.
+     *
+     * @param startDate tournament start date
+     * @return list of matching tournaments
+     */
+    public List<Tournament> searchByStartDate(LocalDate startDate) {
+        return tournamentRepository.findByStartDate(startDate);
+    }
+
+    /**
+     * Searches tournaments by location.
+     *
+     * @param location tournament location
+     * @return list of matching tournaments
+     */
+    public List<Tournament> searchByLocation(String location) {
+        return tournamentRepository.findByLocationContainingIgnoreCase(location);
+    }
+
+    /**
+     * Searches tournaments by member ID.
+     *
+     * @param memberId member ID
+     * @return list of matching tournaments
+     */
+    public List<Tournament> searchByMember(Long memberId) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new RuntimeException("Member not found with id: " + memberId));
+
+        return tournamentRepository.findByMembersContaining(member);
+    }
+
+    /**
+     * Updates an existing tournament.
+     *
+     * @param id tournament ID
+     * @param updatedTournament updated tournament data
+     * @return updated tournament
+     */
+    public Tournament updateTournament(Long id, Tournament updatedTournament) {
+        Tournament existingTournament = tournamentRepository.findById(id)
+                .orElseThrow(() -> new RuntimeException("Tournament not found with id: " + id));
+
+        existingTournament.setStartDate(updatedTournament.getStartDate());
+        existingTournament.setEndDate(updatedTournament.getEndDate());
+        existingTournament.setLocation(updatedTournament.getLocation());
+        existingTournament.setEntryFee(updatedTournament.getEntryFee());
+        existingTournament.setPrize(updatedTournament.getPrize());
+
+        return tournamentRepository.save(existingTournament);
+    }
+
+    /**
+     * Deletes a tournament by ID.
+     *
+     * @param id tournament ID
+     */
+    public void deleteTournament(Long id) {
+        Tournament tournament = tournamentRepository.findById(id)
+                .orElseThrow(() -> new RuntimeException("Tournament not found with id: " + id));
+
+        for (Member member : Set.copyOf(tournament.getMembers())) {
+            tournament.removeMember(member);
+        }
+
+        tournamentRepository.delete(tournament);
+    }
+}


### PR DESCRIPTION
This pull request introduces a comprehensive REST API for managing members and tournaments, including full CRUD operations, advanced search capabilities, and proper entity relationships. It also refactors the data model for improved data integrity and type safety.

**API Layer Additions:**

* Added `MemberController` and `TournamentController` to expose REST endpoints for creating, reading, updating, deleting, and searching members and tournaments. These controllers provide endpoints for advanced queries, such as searching by name, type, date, location, and member participation. 

**Business Logic and Data Access:**

* Introduced `MemberService` and `TournamentService` (not shown, but implied) to encapsulate business logic, including input validation, relationship management, and error handling for member and tournament operations.
* Added `MemberRepository` and `TournamentRepository` with custom query methods for advanced searches (e.g., by name, membership type, phone, tournament date, location, and member participation). [[1]](diffhunk://#diff-2d5670f810be7f0c91907514398952a7602b881fcc132b07018254f6e7299bdfR1-R55) [[2]](diffhunk://#diff-dc8213ad1373c184e60610a5f843944decca38103cc7ef8a8fdf681e723274f2R1-R46)

**Data Model Improvements:**

* Updated the `Member` entity to enforce unique email addresses at the database level and to ignore tournament relationships during JSON serialization to prevent circular references. [[1]](diffhunk://#diff-e3753543461f07b335c5184b00341c608cdd232078ce818b782bac44368f35abR21-R23) [[2]](diffhunk://#diff-e3753543461f07b335c5184b00341c608cdd232078ce818b782bac44368f35abR77)
* Updated the `Tournament` entity to use `LocalDate` for `startDate` and `endDate` fields (instead of `String`), and to enforce uniqueness on the combination of `startDate` and `location`. [[1]](diffhunk://#diff-80169975e55bd879a4c184e00f7c851d4ff26f5794138a6655043bbcf7f7844bR6-R14) [[2]](diffhunk://#diff-80169975e55bd879a4c184e00f7c851d4ff26f5794138a6655043bbcf7f7844bL22-R31) [[3]](diffhunk://#diff-80169975e55bd879a4c184e00f7c851d4ff26f5794138a6655043bbcf7f7844bL77-R89) [[4]](diffhunk://#diff-80169975e55bd879a4c184e00f7c851d4ff26f5794138a6655043bbcf7f7844bL109-R121)

These changes collectively provide a robust backend foundation for managing members and tournaments with strong data integrity, flexible querying, and a clean separation of concerns.